### PR TITLE
fix: send mountpoint info to content-proxy

### DIFF
--- a/src/content-proxy.js
+++ b/src/content-proxy.js
@@ -33,6 +33,7 @@ const PASSTHROUGH_HEADERS = [
  * @param {string}   opts.repo the GitHub repository
  * @param {string}   opts.ref the GitHub ref
  * @param {string}   opts.path the path of the file to retrieve
+ * @param {string}   opts.mp mountpoint
  * @param {object}   opts.log a Helix-Log instance
  * @param {object}   opts.options Helix Fetch options
  * @param {Resolver} opts.resolver Version lock helper
@@ -41,7 +42,7 @@ const PASSTHROUGH_HEADERS = [
  */
 async function contentProxy(opts) {
   const {
-    owner, repo, ref, path, log, options, resolver,
+    owner, repo, ref, path, mp, log, options, resolver,
   } = opts;
   const url = resolver.createURL({
     package: 'helix-services',
@@ -52,6 +53,12 @@ async function contentProxy(opts) {
   url.searchParams.append('repo', repo);
   url.searchParams.append('ref', ref);
   url.searchParams.append('path', path);
+
+  if (mp) {
+    url.searchParams.append('mpType', mp.type);
+    url.searchParams.append('mpRelPath', mp.relPath);
+    url.searchParams.append('mpURL', mp.url);
+  }
 
   url.searchParams.append('rid', options.requestId);
 

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ async function main(req, context) {
     });
 
     const res = await contentProxy({
-      owner, repo, ref, path, log, options, resolver,
+      owner, repo, ref, path, mp, log, options, resolver,
     });
     if (!res.ok) {
       return res;

--- a/test/content-proxy.test.js
+++ b/test/content-proxy.test.js
@@ -67,7 +67,7 @@ describe('Content Proxy Tests', () => {
       mp: {
         type: 'onedrive',
         relPath: '/example-post.md',
-        url: 'https://adobe.sharepoint.com/mymount'
+        url: 'https://adobe.sharepoint.com/mymount',
       },
       log: console,
       options: { },
@@ -86,7 +86,7 @@ describe('Content Proxy Tests', () => {
       mp: {
         type: 'onedrive',
         relPath: '/missing.md',
-        url: 'https://adobe.sharepoint.com/mymount'
+        url: 'https://adobe.sharepoint.com/mymount',
       },
       log: console,
       options: { requestId: '1234' },

--- a/test/content-proxy.test.js
+++ b/test/content-proxy.test.js
@@ -64,6 +64,11 @@ describe('Content Proxy Tests', () => {
       repo: 'bar',
       ref: 'baz',
       path: '/example-post.md',
+      mp: {
+        type: 'onedrive',
+        relPath: '/example-post.md',
+        url: 'https://adobe.sharepoint.com/mymount'
+      },
       log: console,
       options: { },
       resolver,
@@ -78,6 +83,11 @@ describe('Content Proxy Tests', () => {
       repo: 'bar',
       ref: 'baz',
       path: '/missing.md',
+      mp: {
+        type: 'onedrive',
+        relPath: '/missing.md',
+        url: 'https://adobe.sharepoint.com/mymount'
+      },
       log: console,
       options: { requestId: '1234' },
       resolver,


### PR DESCRIPTION
fix #19 

transmits mount point info to content-proxy service so it doesn't need fstab