### PR TITLE
chore: switch to multi-cloud monitoring

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
           statuspage_name: Helix Content Bus
           statuspage_group: Publishing
           newrelic_group_policy: Publishing Repeated Failure
-          newrelic_group_targets: aws, google
+          newrelic_group_targets: aws
           incubator: true # remove only when promoting service to production
 
   branch-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
           statuspage_name: Helix Content Bus
           statuspage_group: Publishing
           newrelic_group_policy: Publishing Repeated Failure
-          newrelic_group_targets: aws
+          # newrelic_group_targets: aws
           incubator: true # remove only when promoting service to production
 
   branch-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
       # see https://circleci.com/orbs/registry/orb/adobe/helix-post-deploy
       # for more available parameters
       - helix-post-deploy/monitoring:
-          targets: aws, google
+          targets: aws
           statuspage_name: Helix Content Bus
           statuspage_group: Publishing
           newrelic_group_policy: Publishing Repeated Failure

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,7 @@ jobs:
           statuspage_group: Publishing
           newrelic_group_policy: Publishing Repeated Failure
           # newrelic_group_targets: aws
+          # action_package: helix-services
           incubator: true # remove only when promoting service to production
 
   branch-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,9 +74,11 @@ jobs:
       # see https://circleci.com/orbs/registry/orb/adobe/helix-post-deploy
       # for more available parameters
       - helix-post-deploy/monitoring:
+          targets: aws, google
           statuspage_name: Helix Content Bus
           statuspage_group: Publishing
           newrelic_group_policy: Publishing Repeated Failure
+          newrelic_group_targets: aws, google
           incubator: true # remove only when promoting service to production
 
   branch-deploy:


### PR DESCRIPTION
See adobe/helix-ops#203

Adding New Relic monitors and Statuspage components for AWS and Google Cloud.